### PR TITLE
Исправление повторяющихся id

### DIFF
--- a/lib/bt.js
+++ b/lib/bt.js
@@ -1,6 +1,12 @@
 var BT = (function() {
 
 /**
+ * Счетчик используемый для генерации уникальных id в методе generateId.
+ * @type {Number}
+ */
+var lastGenId = 0;
+
+/**
  * BT: BtJson -> HTML процессор.
  * @constructor
  */
@@ -50,7 +56,7 @@ function BT() {
     this._options = {};
     this.utils = {
 
-        _lastGenId: 0,
+        _side: (typeof window === 'undefined') ? 's' : 'c',
 
         bt: this,
 
@@ -358,7 +364,7 @@ function BT() {
          * @returns {String}
          */
         generateId: function () {
-            return 'uniq' + (this._lastGenId++);
+            return 'uniq' + this._side + (lastGenId++);
         },
 
         /**


### PR DESCRIPTION
В нашем проекте столкнулся аж с 2 багами при генерации id.
Проявляется так: при клике на label состояние checked ставится чекбоксу в другом блоке.
1. _lastGenId вынес из bt.utils. Так и не понял где же значение не передаётся по ссылке, поэтому закостылил максимально просто. Проверить наличие бага можно создав на клиенте через bt.apply два блока с чекбоксами. id будут повторяться.
2. Часть страницы у нас рендерится на сервере, а часть на клиенте. Соответственно опять получаем повторяющиеся id. Для этого добавлена проверка на существование window и в ключ добавляется "s" для сервера, "c" для клиента. На это существует issue #7

Если можно поправить ошибки менее криво - буду рад комментариям или коммитам.
